### PR TITLE
v9.0.0-rc13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
- "bitcoin 0.32.6",
+ "bitcoin 0.31.2",
  "env_logger",
  "futures",
  "hex",
@@ -3905,6 +3905,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
+ "bitcoin 0.31.2",
  "bytes",
  "clap",
  "console-subscriber",
@@ -3917,6 +3918,7 @@ dependencies = [
  "metashrew-core",
  "metashrew-runtime",
  "metashrew-sync",
+ "metashrew-tests",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
@@ -3934,6 +3936,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wat",
  "zstd 0.13.3",
 ]
 
@@ -4326,6 +4329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "bitcoin_hashes 0.13.0",
+ "rand 0.8.5",
  "secp256k1-sys 0.9.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = "1.0"
 zstd = "0.13"
 
 # Bitcoin dependencies
-bitcoin = "0.32.6"
+bitcoin = "0.31.2"
 hex = "0.4"
 
 # Test dependencies

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Configuration options:
 - `--port`: JSON-RPC port
 - `--label`: Optional database label
 - `--exit-at`: Optional block height to stop at
+- `--prefixroot`: Defines a named, hex-encoded key prefix for which to track a separate SMT root (e.g., `balances:0x...`). Can be specified multiple times or as a comma-separated list.
 
 ## Comparing Indexers with rockshrew-diff
 
@@ -109,6 +110,61 @@ This example compares how two versions of the ALKANES metaprotocol index balance
 - `--start-block`: Block height to start comparison
 - `--exit-at`: Optional block height to stop at
 - `--pipeline-size`: Optional pipeline size for parallel processing (default: 5)
+## Prefix Root State Commitments
+
+Metashrew supports tracking separate Sparse Merkle Tree (SMT) roots for specific key prefixes. This allows for creating state commitments for subsets of the total state, which is useful for protocols that need to verify the integrity of their own data independently.
+
+### Configuration
+
+Use the `--prefixroot` argument to define a named prefix. You can provide multiple arguments or a single comma-separated list.
+
+**Format**: `name:0x<hex_prefix>`
+
+- `name`: A human-readable identifier for the prefix.
+- `hex_prefix`: The key prefix, hex-encoded.
+
+**Example**:
+
+```sh
+./target/release/rockshrew-mono \
+  # ... other args
+  --prefixroot "balances:0x62616c616e6365733a" \
+  --prefixroot "sequence:0x73657175656e63653a"
+```
+
+Or, using a comma-separated list:
+
+```sh
+./target/release/rockshrew-mono \
+  # ... other args
+  --prefixroot "balances:0x62616c616e6365733a,sequence:0x73657175656e63653a"
+```
+
+### Querying Prefix Roots
+
+A new JSON-RPC method, `metashrew_prefixroot`, is available to query the SMT root for a configured prefix at a specific block height.
+
+**Request**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "metashrew_prefixroot",
+  "params": ["<name>", "<height>"]
+}
+```
+
+- `<name>`: The name of the prefix (e.g., `"balances"`).
+- `<height>`: The block height or `"latest"`.
+
+**Response**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0x<root_hash>"
+}
+```
 
 ## WASM Runtime Environment
 

--- a/crates/metashrew-runtime/src/context.rs
+++ b/crates/metashrew-runtime/src/context.rs
@@ -25,6 +25,8 @@
 //! 5. **Cleanup**: Context prepared for next block or operation
 
 use crate::traits::KeyValueStoreLike;
+use crate::smt::BatchedSMTHelper;
+use std::collections::HashMap;
 
 /// Execution context for WebAssembly indexer modules
 ///
@@ -105,6 +107,12 @@ pub struct MetashrewRuntimeContext<T: KeyValueStoreLike> {
     /// - `1`: Execution completed successfully
     /// - Other values may indicate error conditions
     pub state: u32,
+
+    /// Configurations for prefix-based SMT roots
+    pub prefix_configs: Vec<(String, Vec<u8>)>,
+
+    /// Calculated SMT roots for each configured prefix
+    pub prefix_smts: HashMap<String, BatchedSMTHelper<T>>,
 }
 
 impl<T: KeyValueStoreLike> Clone for MetashrewRuntimeContext<T>
@@ -117,11 +125,13 @@ where
             height: self.height,
             block: self.block.clone(),
             state: self.state,
+            prefix_configs: self.prefix_configs.clone(),
+            prefix_smts: self.prefix_smts.clone(),
         }
     }
 }
 
-impl<T: KeyValueStoreLike> MetashrewRuntimeContext<T> {
+impl<T: KeyValueStoreLike + Clone> MetashrewRuntimeContext<T> {
     /// Create a new runtime context with the specified parameters
     ///
     /// Initializes a new execution context for WASM indexer modules with
@@ -166,12 +176,18 @@ impl<T: KeyValueStoreLike> MetashrewRuntimeContext<T> {
     ///     MetashrewRuntimeContext::new(storage, height, block_data)
     /// ));
     /// ```
-    pub fn new(db: T, height: u32, block: Vec<u8>) -> Self {
+    pub fn new(db: T, height: u32, block: Vec<u8>, prefix_configs: Vec<(String, Vec<u8>)>) -> Self {
+        let mut prefix_smts = HashMap::new();
+        for (name, _) in prefix_configs.iter() {
+            prefix_smts.insert(name.clone(), BatchedSMTHelper::new(db.clone()));
+        }
         Self {
             db,
             height,
             block,
             state: 0,
+            prefix_configs,
+            prefix_smts,
         }
     }
 }

--- a/crates/metashrew-runtime/src/lib.rs
+++ b/crates/metashrew-runtime/src/lib.rs
@@ -19,6 +19,7 @@ pub use traits::{BatchLike, KVTrackerFn, KeyValueStoreLike};
 
 // Re-export helper types
 pub use smt::{BatchedSMTHelper, SMTHelper, SMTNode};
+pub use key_utils::decode_historical_key;
 
 // Utility functions that are storage-backend agnostic
 static mut _LABEL: Option<String> = None;

--- a/crates/metashrew-sync/src/mock.rs
+++ b/crates/metashrew-sync/src/mock.rs
@@ -247,6 +247,7 @@ pub struct MockRuntime {
     blocks_processed: Arc<Mutex<u32>>,
     ready: Arc<RwLock<bool>>,
     memory_usage: Arc<Mutex<usize>>,
+    pub prefix_roots: Arc<Mutex<HashMap<String, [u8; 32]>>>,
 }
 
 impl MockRuntime {
@@ -255,6 +256,7 @@ impl MockRuntime {
             blocks_processed: Arc::new(Mutex::new(0)),
             ready: Arc::new(RwLock::new(true)),
             memory_usage: Arc::new(Mutex::new(1024 * 1024)),
+            prefix_roots: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -384,5 +386,14 @@ impl RuntimeAdapter for MockRuntime {
             blocks_processed,
             last_refresh_height: Some(blocks_processed),
         })
+    }
+
+    async fn get_prefix_root(&self, name: &str, _height: u32) -> SyncResult<Option<[u8; 32]>> {
+        let roots = self.prefix_roots.lock().await;
+        Ok(roots.get(name).cloned())
+    }
+
+    async fn log_prefix_roots(&self) -> SyncResult<()> {
+        Ok(())
     }
 }

--- a/crates/metashrew-sync/src/traits.rs
+++ b/crates/metashrew-sync/src/traits.rs
@@ -268,6 +268,11 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Get runtime statistics
     async fn get_stats(&self) -> SyncResult<RuntimeStats>;
 
+    /// Get a prefix state root at a specific height
+    async fn get_prefix_root(&self, name: &str, height: u32) -> SyncResult<Option<[u8; 32]>>;
+
+    async fn log_prefix_roots(&self) -> SyncResult<()>;
+
     /// Track runtime updates for snapshot creation (optional, used in snapshot mode)
     /// This method should be called after successful block processing to capture
     /// key-value changes for snapshot diff generation
@@ -329,6 +334,9 @@ pub trait JsonRpcProvider: Send + Sync {
 
     /// Get snapshot information
     async fn metashrew_snapshot(&self) -> SyncResult<serde_json::Value>;
+
+    /// Get a prefix state root by name and height
+    async fn metashrew_prefixroot(&self, name: String, height: String) -> SyncResult<String>;
 }
 
 /// Trait for the complete sync engine that coordinates all components

--- a/crates/rockshrew-mono/Cargo.toml
+++ b/crates/rockshrew-mono/Cargo.toml
@@ -50,6 +50,10 @@ tokio-test = "0.4"
 tempfile = "3.8"
 memshrew-runtime = { path = "../memshrew" }
 metashrew-core = { path = "../metashrew-core" }
+wat = "1.235.0"
+metashrew-sync = { path = "../metashrew-sync", features = ["test-utils"] }
+bitcoin = { version = "0.31.2", features = ["rand"] }
+metashrew-tests = { path = "../../" }
 
 
 [profile.release]

--- a/crates/rockshrew-mono/src/lib.rs
+++ b/crates/rockshrew-mono/src/lib.rs
@@ -111,6 +111,8 @@ pub struct Args {
     pub max_reorg_depth: u32,
     #[arg(long, default_value_t = 6)]
     pub reorg_check_threshold: u32,
+    #[arg(long)]
+    pub prefixroot: Vec<String>,
 }
 
 /// Shared application state for the JSON-RPC server.
@@ -137,6 +139,7 @@ where
 {
     let request: serde_json::Value = body.into_inner();
     let method = request["method"].as_str().unwrap_or_default();
+    info!("Received RPC method: '{}'", method);
     let empty_params = vec![];
     let params = request["params"].as_array().unwrap_or(&empty_params);
     let id = request["id"].clone();
@@ -176,6 +179,11 @@ where
             state.sync_engine.read().await.metashrew_stateroot(height).await
         }
         "metashrew_snapshot" => state.sync_engine.read().await.metashrew_snapshot().await.map(|v| v.to_string()),
+        "metashrew_prefixroot" => {
+            let name = params[0].as_str().unwrap_or_default().to_string();
+            let height = params[1].as_str().unwrap_or("latest").to_string();
+            state.sync_engine.read().await.metashrew_prefixroot(name, height).await
+        }
         _ => Err(anyhow::anyhow!("Method not found").into()),
     };
 
@@ -307,6 +315,17 @@ where
                         }
                         
                         debug!("Processed block {} in {:?}", height, block_duration);
+
+                        // Log prefix roots
+                        let runtime_adapter = engine.runtime.read().await;
+                        if let Err(e) = runtime_adapter.log_prefix_roots().await {
+                            error!("Failed to log prefix roots: {}", e);
+                        }
+
+
+                        if Some(height) == engine.config.exit_at {
+                            break;
+                        }
                         // Successfully processed a block, continue immediately
                         continue;
                     }
@@ -393,6 +412,8 @@ where
 // RocksDB configuration has been moved to rockshrew-runtime/src/optimized_config.rs
 // for better organization and reusability across the codebase.
 
+use hex::FromHex;
+
 /// Production-specific run function.
 pub async fn run_prod(args: Args) -> Result<()> {
     let (rpc_url, bypass_ssl, tunnel_config) =
@@ -402,10 +423,26 @@ pub async fn run_prod(args: Args) -> Result<()> {
     info!("Database path: {}", args.db_path.display());
     info!("Optimizations: bloom filter tuning, cache optimization, reduced I/O overhead");
 
+    let prefix_configs = args
+        .prefixroot
+        .iter()
+        .map(|s| {
+            let parts: Vec<&str> = s.split(':').collect();
+            if parts.len() != 2 {
+                return Err(anyhow!("Invalid prefixroot format: {}", s));
+            }
+            let name = parts[0].to_string();
+            let prefix_hex = parts[1].strip_prefix("0x").unwrap_or(parts[1]);
+            let prefix = Vec::from_hex(prefix_hex)?;
+            Ok((name, prefix))
+        })
+        .collect::<Result<Vec<(String, Vec<u8>)>>>()?;
+
     // Use the optimized configuration from rockshrew-runtime based on performance analysis
     let runtime = MetashrewRuntime::load(
         args.indexer.clone(),
         RocksDBRuntimeAdapter::open_optimized(args.db_path.to_string_lossy().to_string())?,
+        prefix_configs,
     )?;
 
     let db = {

--- a/crates/rockshrew-mono/src/lib.rs
+++ b/crates/rockshrew-mono/src/lib.rs
@@ -426,6 +426,7 @@ pub async fn run_prod(args: Args) -> Result<()> {
     let prefix_configs = args
         .prefixroot
         .iter()
+        .flat_map(|s| s.split(','))
         .map(|s| {
             let parts: Vec<&str> = s.split(':').collect();
             if parts.len() != 2 {

--- a/crates/rockshrew-mono/src/tests/mod.rs
+++ b/crates/rockshrew-mono/src/tests/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod rocksdb_optimization_test;
 pub mod snapshot_sync_test;
+pub mod prefixroot_test;

--- a/crates/rockshrew-mono/src/tests/prefixroot_test.rs
+++ b/crates/rockshrew-mono/src/tests/prefixroot_test.rs
@@ -1,0 +1,54 @@
+// crates/rockshrew-mono/src/tests/prefixroot_test.rs
+
+/*
+ * Chadson v69.0.0
+ *
+ * This file contains the in-memory tests for the --prefixroot functionality.
+ *
+ * Purpose:
+ * - To test the `metashrew_prefixroot` JSON-RPC method in a mocked environment.
+ */
+
+use metashrew_sync::{
+    mock::{MockBitcoinNode, MockRuntime, MockStorage},
+    JsonRpcProvider, SnapshotMetashrewSync, SyncConfig, SyncMode,
+};
+use std::sync::atomic::Ordering;
+
+#[tokio::test]
+async fn test_prefixroot_in_memory() {
+    // 1. Setup mocked components
+    let node = MockBitcoinNode::new();
+    let storage = MockStorage::new();
+    let runtime = MockRuntime::new();
+
+    // 2. Pre-populate the mock runtime with a known prefix root
+    let prefix_name = "test_prefix".to_string();
+    let expected_root = [1; 32];
+    runtime
+        .prefix_roots
+        .lock()
+        .await
+        .insert(prefix_name.clone(), expected_root.clone());
+
+    // 3. Create the sync engine instance with the mocks
+    let sync_engine = SnapshotMetashrewSync::new(
+        node,
+        storage,
+        runtime,
+        SyncConfig::default(),
+        SyncMode::Normal,
+    );
+
+    // Set a mock height for the query
+    sync_engine.current_height.store(1, Ordering::SeqCst);
+
+    // 4. Directly call the `metashrew_prefixroot` method
+    let result = sync_engine
+        .metashrew_prefixroot(prefix_name, "0".to_string())
+        .await
+        .unwrap();
+
+    // 5. Assert that the result matches the expected root
+    assert_eq!(result, format!("0x{}", hex::encode(expected_root)));
+}

--- a/crates/rockshrew-runtime/src/adapter.rs
+++ b/crates/rockshrew-runtime/src/adapter.rs
@@ -132,6 +132,7 @@ impl RocksDBRuntimeAdapter {
     pub fn write_atomic_batch(&self, batch: WriteBatch) -> Result<(), rocksdb::Error> {
         self.db.write(batch)
     }
+
 }
 
 pub struct RocksDBBatch(pub WriteBatch);

--- a/src/block_builder.rs
+++ b/src/block_builder.rs
@@ -118,14 +118,13 @@ impl BlockBuilder {
         }
 
         // Calculate merkle root
-        let txids: Vec<Txid> = transactions.iter().map(|tx| tx.compute_txid()).collect();
-        let merkle_root = bitcoin::merkle_tree::calculate_root(txids.into_iter())
-            .unwrap_or_else(|| Txid::all_zeros());
+        let txids: Vec<Txid> = transactions.iter().map(|tx| tx.txid()).collect();
+        let merkle_root = bitcoin::merkle_tree::calculate_root(txids.into_iter()).map(|h| h.to_raw_hash()).unwrap_or(bitcoin::hashes::sha256d::Hash::all_zeros()).into();
 
         let header = BlockHeader {
             version: bitcoin::blockdata::block::Version::ONE,
             prev_blockhash: self.prev_hash,
-            merkle_root: merkle_root.into(),
+            merkle_root,
             time: self.timestamp,
             bits: bitcoin::CompactTarget::from_consensus(0x1d00ffff),
             nonce: self.nonce,

--- a/src/in_memory_adapters.rs
+++ b/src/in_memory_adapters.rs
@@ -18,7 +18,7 @@ impl InMemoryBitcoinNode {
         let mut blocks = HashMap::new();
         let tip = ChainTip {
             height: 0,
-            hash: genesis_block.block_hash().to_byte_array().to_vec(),
+            hash: genesis_block.block_hash().as_byte_array().to_vec(),
         };
         blocks.insert(0, genesis_block);
         Self {
@@ -31,7 +31,7 @@ impl InMemoryBitcoinNode {
         let mut blocks = self.blocks.write().unwrap();
         let mut tip = self.tip.write().unwrap();
         tip.height = height;
-        tip.hash = block.block_hash().to_byte_array().to_vec();
+        tip.hash = block.block_hash().as_byte_array().to_vec();
         blocks.insert(height, block);
     }
 }
@@ -47,7 +47,7 @@ impl BitcoinNodeAdapter for InMemoryBitcoinNode {
             .read()
             .unwrap()
             .get(&height)
-            .map(|b| b.block_hash().to_byte_array().to_vec())
+            .map(|b| b.block_hash().as_byte_array().to_vec())
             .ok_or_else(|| SyncError::BitcoinNode(format!("Block not found at height {}", height)))
     }
 
@@ -56,7 +56,7 @@ impl BitcoinNodeAdapter for InMemoryBitcoinNode {
             .read()
             .unwrap()
             .get(&height)
-            .map(|b| metashrew_support::utils::consensus_encode(b).unwrap())
+            .map(|b| bitcoin::consensus::serialize(b))
             .ok_or_else(|| SyncError::BitcoinNode(format!("Block not found at height {}", height)))
     }
 
@@ -70,8 +70,8 @@ impl BitcoinNodeAdapter for InMemoryBitcoinNode {
             .ok_or_else(|| SyncError::BitcoinNode(format!("Block not found at height {}", height)))?;
         Ok(BlockInfo {
             height,
-            hash: block.block_hash().to_byte_array().to_vec(),
-            data: metashrew_support::utils::consensus_encode(&block).unwrap(),
+            hash: block.block_hash().as_byte_array().to_vec(),
+            data: bitcoin::consensus::serialize(&block),
         })
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -26,14 +26,14 @@ impl TestConfig {
 
     /// Create a new MetashrewRuntime for testing
     pub fn create_runtime(&self) -> Result<MetashrewRuntime<MemStoreAdapter>> {
-        MetashrewRuntime::new(self.wasm, MemStoreAdapter::new())
+        MetashrewRuntime::new(self.wasm, MemStoreAdapter::new(), vec![])
     }
 
     pub fn create_runtime_from_adapter<T: KeyValueStoreLike + Clone + Send + Sync + 'static>(
         &self,
         store: T,
     ) -> Result<MetashrewRuntime<T>> {
-        MetashrewRuntime::new(self.wasm, store)
+        MetashrewRuntime::new(self.wasm, store, vec![])
     }
 }
 
@@ -50,7 +50,7 @@ impl TestUtils {
     /// Creates a simple test block with a specified height and previous block hash.
     pub fn create_test_block(height: u32, prev_hash: BlockHash) -> Block {
         let txdata: Vec<Transaction> = vec![];
-        let merkle_root = bitcoin::merkle_tree::calculate_root(txdata.iter().map(|tx| tx.compute_txid()))
+        let merkle_root = bitcoin::merkle_tree::calculate_root(txdata.iter().map(|tx| tx.txid()))
             .map(|hash| TxMerkleNode::from_raw_hash(hashes::sha256d::Hash::from_byte_array(hash.to_byte_array())))
             .unwrap_or(TxMerkleNode::all_zeros());
         let header = Header {


### PR DESCRIPTION
--prefixroot flag

Updated README.md to discuss feature

Allows --prefixroot 'balances:2f72756e65732f70726f746f2f312f62796f7574706f696e742f,sequence:2f616c6b616e65732f73657175656e6365' to trivially compare global balance sheet state wrt alkanes + track sequence number mutation