### PR TITLE
kungfuflex/v9.0.1-alpha.2

### DIFF
--- a/crates/metashrew-runtime/src/runtime.rs
+++ b/crates/metashrew-runtime/src/runtime.rs
@@ -1,15 +1,3 @@
-// Chadson-v69.1.0: Journal
-//
-// Objective: Modify the runtime to halt on any WASM error during `runtime.run()`.
-//
-// 1.  Identified `run()` and `process_block_atomic()` in `crates/metashrew-runtime/src/runtime.rs`
-//     as the key functions handling WASM execution via `start.call()`.
-// 2.  The current implementation catches `wasmtime::Error` and returns it as a `Result`.
-// 3.  The requirement is to panic instead of returning an error, to halt the process.
-// 4.  Modified the `Err` arm of the `match start.call(...)` in both functions to `panic!`.
-// 5.  The `preview` function was intentionally left unchanged as it is likely used in contexts
-//     where halting the entire process is undesirable (e.g., read-only queries).
-
 //! Core WebAssembly runtime for executing Bitcoin indexers
 //!
 //! This module provides the main [`MetashrewRuntime`] struct that executes WebAssembly
@@ -951,7 +939,7 @@ impl<T: KeyValueStoreLike + Clone + Send + Sync + 'static> MetashrewRuntime<T> {
                     Ok(())
                 }
             }
-            Err(e) => panic!("WASM execution failed in run: {:?}", e),
+            Err(e) => Err(e).context("Error calling _start function"),
         };
 
         // ALWAYS refresh memory after block execution for deterministic behavior
@@ -1952,7 +1940,7 @@ impl<T: KeyValueStoreLike + Clone + Send + Sync + 'static> MetashrewRuntime<T> {
                     Ok(())
                 }
             }
-            Err(e) => panic!("WASM execution failed in atomic processing: {:?}", e),
+            Err(e) => Err(e).context("Error calling _start function in atomic processing"),
         };
 
         // Calculate the state root and batch data before memory refresh

--- a/crates/rockshrew-mono/src/lib.rs
+++ b/crates/rockshrew-mono/src/lib.rs
@@ -317,14 +317,8 @@ where
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     }
                     Err(e) => {
-                        // CRITICAL FIX: Don't advance to next block on error!
-                        // The process_next_block() method internally manages height,
-                        // but on error we need to retry the SAME block, not skip it.
-                        let error_duration = block_start.elapsed();
-                        error!("Indexer error after {:?}: {}", error_duration, e);
-                        drop(engine); // Release the lock before sleeping
-                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                        // Continue the loop to retry the same block
+                        error!("Fatal indexer error: {}. Shutting down.", e);
+                        break; // Exit the loop on any error for graceful shutdown
                     }
                 }
             }


### PR DESCRIPTION
Properly shutdown rockshrew-mono in the event of a WASM panic, without any retry logic.