### PR TITLE
v9.0.5-rc.13: CPU isolation + view runtime + fetcher wedge fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,6 +3814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3856,6 +3865,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "reqwest",
+ "rlimit",
  "rocksdb",
  "rockshrew-runtime",
  "russh",

--- a/crates/metashrew-runtime/src/runtime.rs
+++ b/crates/metashrew-runtime/src/runtime.rs
@@ -84,6 +84,58 @@ use crate::traits::{BatchLike, KeyValueStoreLike};
 /// that has been successfully processed and committed to the database.
 pub const TIP_HEIGHT_KEY: &'static str = "/__INTERNAL/tip-height";
 
+/// Build a `wasmtime::Config` with the deterministic flags every
+/// metashrew indexer engine MUST use.
+///
+/// This is the single source of truth: `MetashrewRuntime::{load,new}`
+/// call it to build both the indexer engine and (with two extra
+/// flags) the view engine. External crates that need to construct
+/// their own engine for testing or specialty use cases should call
+/// this rather than reach for `wasmtime::Config::default()` directly.
+///
+/// Flags set, with rationale:
+/// - `cranelift_nan_canonicalization(true)` — float NaN payloads
+///   canonicalize across hardware (x86-64 vs ARM, SSE/AVX
+///   variants). Alkanes doesn't currently use floats, but nested
+///   wasmi sub-instances inside an alkane *can*, and any future
+///   wasm protocol might. Belt-and-suspenders.
+/// - `relaxed_simd_deterministic(true)` — relaxed SIMD ops produce
+///   different results on different CPUs without this flag. Same
+///   risk class as floats.
+/// - `memory_reservation(0x100000000)` — 4 GiB mmap'd up front so
+///   `memory.grow` doesn't need to syscall mid-execution. Without
+///   this, a host under memory pressure can fail `memory.grow`
+///   mid-block, producing a different runtime error path than a
+///   host with headroom — the same input wasm produces different
+///   write paths.
+/// - `memory_guard_size(0x10000)` — 64 KiB guard page so OOB
+///   memory accesses trap predictably instead of corrupting host
+///   memory.
+/// - `memory_init_cow(false)` — disable copy-on-write so two
+///   instances of the same module don't share underlying pages.
+///   Defense against accidental cross-instance state contamination.
+/// - `async_support(true)` — required because the indexer runs via
+///   `instantiate_async` + `start.call_async`.
+///
+/// Flags intentionally NOT set on the indexer engine, but flipped
+/// on the VIEW engine in `load()`/`new()`:
+/// - `wasm_threads(true)` — view-only. Consensus-critical that the
+///   indexer wasm cannot use shared memory + atomics; those
+///   semantics are not deterministic across thread schedules.
+/// - `consume_fuel(true)` — view-only. The indexer doesn't meter
+///   per-instruction fuel (it metered per-block via FuelTank at
+///   the alkanes layer).
+pub fn indexer_config() -> wasmtime::Config {
+    let mut config = wasmtime::Config::default();
+    config.cranelift_nan_canonicalization(true);
+    config.relaxed_simd_deterministic(true);
+    config.memory_reservation(0x100000000);
+    config.memory_guard_size(0x10000);
+    config.memory_init_cow(false);
+    config.async_support(true);
+    config
+}
+
 fn lock_err<T>(err: std::sync::PoisonError<T>) -> anyhow::Error {
     anyhow!("Mutex lock error: {}", err)
 }
@@ -431,23 +483,35 @@ impl<T: KeyValueStoreLike + Clone + Send + Sync + 'static> MetashrewRuntime<T> {
     ///     my_storage_backend
     /// )?;
     /// ```
-    pub async fn load(indexer: PathBuf, mut store: T, engine: wasmtime::Engine) -> Result<Self> where <T as KeyValueStoreLike>::Batch: Send {
-        // Configure the engine with settings for deterministic execution
-        let mut config = wasmtime::Config::default();
-        // Enable NaN canonicalization for deterministic floating point operations
-        config.cranelift_nan_canonicalization(true);
-        // Make relaxed SIMD deterministic (or disable it if not needed)
-        config.relaxed_simd_deterministic(true);
-        // Allocate memory at maximum size to avoid non-deterministic memory growth
-        config.memory_reservation(0x100000000); // 4GB max memory
-        config.memory_guard_size(0x10000); // 64KB guard
-                                                  // Pre-allocate memory to maximum size
-        config.memory_init_cow(false); // Disable copy-on-write to ensure consistent memory behavior
+    pub async fn load(indexer: PathBuf, mut store: T) -> Result<Self> where <T as KeyValueStoreLike>::Batch: Send {
+        // Both engines are built from the same deterministic-config base
+        // (see `indexer_config`). The view engine adds consume_fuel +
+        // wasm_threads (defense-in-depth — v9 doesn't expose the
+        // ThreadSpawn/ThreadJoin host syscalls, so wasm_threads here
+        // just allows shared-memory wasm modules to load without
+        // changing host-side behavior).
+        //
+        // History: prior to this commit, callers (rockshrew-mono)
+        // constructed the indexer engine themselves with only
+        // `async_support(true)` set and passed it in via an
+        // `engine: wasmtime::Engine` parameter on this function. The
+        // deterministic flags (NaN canonicalization, memory_reservation
+        // 4 GiB, memory_init_cow false, relaxed-SIMD-deterministic)
+        // only ever landed on the view-side async_engine the function
+        // built internally. The indexer engine — the one actually
+        // writing state — was bare defaults. This is the leading
+        // hypothesis for the g vs h 907-DIESEL drift at h=950299
+        // (same image, same wasm, same start time, divergent state).
+        //
+        // Fix: load() / new() now build BOTH engines internally from
+        // `indexer_config()` so determinism is guaranteed-by-construction.
+        // The `engine` parameter is gone.
+        let config = indexer_config();
+        let engine = wasmtime::Engine::new(&config)?;
 
-        // Configure async engine with the same deterministic settings
         let mut async_config = config.clone();
         async_config.consume_fuel(true);
-        async_config.async_support(true);
+        async_config.wasm_threads(true);
 
         let async_engine = wasmtime::Engine::new(&async_config)?;
         let module = wasmtime::Module::from_file(&engine, indexer.clone().into_os_string())
@@ -491,23 +555,15 @@ impl<T: KeyValueStoreLike + Clone + Send + Sync + 'static> MetashrewRuntime<T> {
         })
     }
 
-    pub async fn new(indexer: &[u8], mut store: T, engine: wasmtime::Engine) -> Result<Self> where <T as KeyValueStoreLike>::Batch: Send {
-        // Configure the engine with settings for deterministic execution
-        let mut config = wasmtime::Config::default();
-        // Enable NaN canonicalization for deterministic floating point operations
-        config.cranelift_nan_canonicalization(true);
-        // Make relaxed SIMD deterministic (or disable it if not needed)
-        config.relaxed_simd_deterministic(true);
-        // Allocate memory at maximum size to avoid non-deterministic memory growth
-        config.memory_reservation(0x100000000); // 4GB max memory
-        config.memory_guard_size(0x10000); // 64KB guard
-                                                  // Pre-allocate memory to maximum size
-        config.memory_init_cow(false); // Disable copy-on-write to ensure consistent memory behavior
+    pub async fn new(indexer: &[u8], mut store: T) -> Result<Self> where <T as KeyValueStoreLike>::Batch: Send {
+        // See `load()` for the rationale on internal engine construction.
+        // Same deterministic-config base; same indexer/view split.
+        let config = indexer_config();
+        let engine = wasmtime::Engine::new(&config)?;
 
-        // Configure async engine with the same deterministic settings
         let mut async_config = config.clone();
         async_config.consume_fuel(true);
-        async_config.async_support(true);
+        async_config.wasm_threads(true);
 
         let async_engine = wasmtime::Engine::new(&async_config)?;
         let module = wasmtime::Module::new(&engine, indexer)

--- a/crates/metashrew-sync/Cargo.toml
+++ b/crates/metashrew-sync/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.95"
-tokio = { version = "1.43.0", features = ["full"] }
+tokio = { version = "1.43.0", features = ["full", "test-util"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.136"
 log = "0.4.25"

--- a/crates/metashrew-sync/src/snapshot_sync.rs
+++ b/crates/metashrew-sync/src/snapshot_sync.rs
@@ -182,8 +182,33 @@ where
     }
 
     pub async fn get_next_block_data(&self) -> SyncResult<Option<(u32, Vec<u8>, Vec<u8>)>> {
+        self.get_next_block_data_with_floor(None).await
+    }
+
+    /// v9.0.5-rc.13: `min_target_height` floor for the next-block-to-fetch
+    /// decision. Defends against the fetcher-wedge bug where
+    /// `handle_reorg` silently lowers `self.current_height` (in non-reorg
+    /// edge cases — e.g. a transient bouncer/bitcoind hash mismatch) and
+    /// then `get_next_block_data` re-fetches a block the fetcher's outer
+    /// loop already sent to the processor. The outer loop drops the
+    /// duplicate (via `near_tip_should_drop`), the processor idles
+    /// forever, and the pod wedges. Production saw j stuck at height
+    /// 951049 for 8+ minutes (block 951049 committed at 01:03:28; fetcher
+    /// kept getting back 951049 because current_height never advanced
+    /// past it).
+    ///
+    /// When `min_target_height = Some(M)`, after the (still-honored)
+    /// reorg check, this method clamps the in-use height to `max(
+    /// effective_current_height, M)` so the fetcher never re-fetches
+    /// what the outer loop has already enqueued. Reorg detection still
+    /// runs and still rewinds `self.current_height` if a real reorg is
+    /// found; the floor only changes which block is RETURNED here.
+    pub async fn get_next_block_data_with_floor(
+        &self,
+        min_target_height: Option<u32>,
+    ) -> SyncResult<Option<(u32, Vec<u8>, Vec<u8>)>> {
         let mut current_height = self.current_height.load(Ordering::SeqCst);
-        
+
         // Get remote tip
         let remote_tip = self.node.get_tip_height().await?;
 
@@ -212,35 +237,44 @@ where
             }
         }
 
+        // v9.0.5-rc.13: apply the floor AFTER the reorg check so a real
+        // reorg's rollback still takes effect, but a phantom rollback
+        // (no-op reorg detection that happened to clamp current_height)
+        // can't cause a wedge.
+        let fetch_height = match min_target_height {
+            Some(m) if m > current_height => m,
+            _ => current_height,
+        };
+
         // Check exit condition
         if let Some(exit_at) = self.config.exit_at {
-            if current_height >= exit_at {
+            if fetch_height >= exit_at {
                 info!("Fetcher reached exit height {}", exit_at);
                 return Ok(None);
             }
         }
 
         // Check if we need to wait for new blocks
-        if current_height > remote_tip {
+        if fetch_height > remote_tip {
             debug!(
-                "Waiting for new blocks: current={}, tip={}",
-                current_height, remote_tip
+                "Waiting for new blocks: fetch_height={}, tip={}",
+                fetch_height, remote_tip
             );
             return Ok(None);
         }
 
         // Fetch block
-        match self.node.get_block_info(current_height).await {
+        match self.node.get_block_info(fetch_height).await {
             Ok(block_info) => {
                 info!(
                     "Fetched block {} ({} bytes)",
-                    current_height,
+                    fetch_height,
                     block_info.data.len()
                 );
-                Ok(Some((current_height, block_info.data, block_info.hash)))
+                Ok(Some((fetch_height, block_info.data, block_info.hash)))
             }
             Err(e) => {
-                error!("Failed to fetch block {}: {}", current_height, e);
+                error!("Failed to fetch block {}: {}", fetch_height, e);
                 Err(e.into())
             }
         }

--- a/crates/metashrew-sync/src/snapshot_sync.rs
+++ b/crates/metashrew-sync/src/snapshot_sync.rs
@@ -366,6 +366,7 @@ where
         }
 
         let mut attempt: u32 = 0;
+        let mut last_err: Option<String> = None;
         loop {
             attempt = attempt.saturating_add(1);
 
@@ -389,6 +390,23 @@ where
                     height, current, attempt
                 );
                 return Ok(());
+            }
+
+            // Max-attempts bound (companion to the staleness guard above):
+            // covers the OTHER way the retry loop wedged in production,
+            // where commit_atomic returns a non-staleness error every time
+            // (mork1e 2026-05-21: block 892936 retried 600+ attempts on
+            // "Too many open files"). See MAX_ATOMIC_COMMIT_ATTEMPTS in
+            // sync.rs for the rationale on the specific cap.
+            if attempt > crate::sync::MAX_ATOMIC_COMMIT_ATTEMPTS {
+                let msg = last_err.unwrap_or_else(|| "no error captured".to_string());
+                return Err(SyncError::Storage(format!(
+                    "snapshot-path: commit_atomic at height {} exceeded \
+                     max-retry budget ({} attempts): last error: {}",
+                    height,
+                    crate::sync::MAX_ATOMIC_COMMIT_ATTEMPTS,
+                    msg
+                )));
             }
 
             if attempt > 1 {
@@ -421,22 +439,26 @@ where
                             return Ok(());
                         }
                         Err(commit_err) => {
+                            let msg = format!("{}", commit_err);
                             crate::sync::log_atomic_retry_failure(
                                 "snapshot-path atomic commit",
                                 height,
                                 attempt,
-                                &format!("{}", commit_err),
+                                &msg,
                             );
+                            last_err = Some(format!("commit_atomic: {}", msg));
                         }
                     }
                 }
                 Err(atomic_err) => {
+                    let msg = format!("{}", atomic_err);
                     crate::sync::log_atomic_retry_failure(
                         "snapshot-path atomic block execution",
                         height,
                         attempt,
-                        &format!("{}", atomic_err),
+                        &msg,
                     );
+                    last_err = Some(format!("process_block_atomic: {}", msg));
                 }
             }
 
@@ -556,6 +578,7 @@ where
         let block_hash = self.node.get_block_hash(height).await?;
 
         let mut attempt: u32 = 0;
+        let mut last_err: Option<String> = None;
         loop {
             attempt = attempt.saturating_add(1);
 
@@ -573,6 +596,22 @@ where
                     height, current, attempt
                 );
                 return Ok(());
+            }
+
+            // Max-attempts bound: see MAX_ATOMIC_COMMIT_ATTEMPTS in sync.rs
+            // for the rationale (mork1e's 600-attempt wedge on block
+            // 892936 with persistent "Too many open files"). At this
+            // cap the loop has been retrying for ~10-15 minutes against
+            // a persistent failure — operator needs the signal.
+            if attempt > crate::sync::MAX_ATOMIC_COMMIT_ATTEMPTS {
+                let msg = last_err.unwrap_or_else(|| "no error captured".to_string());
+                return Err(SyncError::Storage(format!(
+                    "snapshot-loop: commit_atomic at height {} exceeded \
+                     max-retry budget ({} attempts): last error: {}",
+                    height,
+                    crate::sync::MAX_ATOMIC_COMMIT_ATTEMPTS,
+                    msg
+                )));
             }
 
             if attempt > 1 {
@@ -630,22 +669,26 @@ where
                             return Ok(());
                         }
                         Err(commit_err) => {
+                            let msg = format!("{}", commit_err);
                             crate::sync::log_atomic_retry_failure(
                                 "snapshot-loop atomic commit",
                                 height,
                                 attempt,
-                                &format!("{}", commit_err),
+                                &msg,
                             );
+                            last_err = Some(format!("commit_atomic: {}", msg));
                         }
                     }
                 }
                 Err(atomic_err) => {
+                    let msg = format!("{}", atomic_err);
                     crate::sync::log_atomic_retry_failure(
                         "snapshot-loop atomic execution",
                         height,
                         attempt,
-                        &format!("{}", atomic_err),
+                        &msg,
                     );
+                    last_err = Some(format!("process_block_atomic: {}", msg));
                 }
             }
 

--- a/crates/metashrew-sync/src/sync.rs
+++ b/crates/metashrew-sync/src/sync.rs
@@ -377,8 +377,20 @@ where
     }
 
     pub async fn get_next_block_data(&self) -> SyncResult<Option<(u32, Vec<u8>, Vec<u8>)>> {
+        self.get_next_block_data_with_floor(None).await
+    }
+
+    /// v9.0.5-rc.13: `min_target_height` floor for the next-block-to-fetch
+    /// decision. See `SnapshotMetashrewSync::get_next_block_data_with_floor`
+    /// for the full motivation — the short version is "defend against
+    /// fetcher wedging when handle_reorg silently lowers current_height
+    /// past what the outer fetcher loop already enqueued".
+    pub async fn get_next_block_data_with_floor(
+        &self,
+        min_target_height: Option<u32>,
+    ) -> SyncResult<Option<(u32, Vec<u8>, Vec<u8>)>> {
         let mut current_height = self.current_height.load(Ordering::SeqCst);
-        
+
         // Get remote tip
         let remote_tip = self.node.get_tip_height().await?;
 
@@ -407,35 +419,43 @@ where
             }
         }
 
+        // v9.0.5-rc.13: clamp the fetch target to >= min_target_height so
+        // the outer fetcher loop's `last_sent + 1` watermark always wins
+        // over a phantom-rolled-back current_height.
+        let fetch_height = match min_target_height {
+            Some(m) if m > current_height => m,
+            _ => current_height,
+        };
+
         // Check exit condition
         if let Some(exit_at) = self.config.exit_at {
-            if current_height >= exit_at {
+            if fetch_height >= exit_at {
                 info!("Fetcher reached exit height {}", exit_at);
                 return Ok(None);
             }
         }
 
         // Check if we need to wait for new blocks
-        if current_height > remote_tip {
+        if fetch_height > remote_tip {
             debug!(
-                "Waiting for new blocks: current={}, tip={}",
-                current_height, remote_tip
+                "Waiting for new blocks: fetch_height={}, tip={}",
+                fetch_height, remote_tip
             );
             return Ok(None);
         }
 
         // Fetch block
-        match self.node.get_block_info(current_height).await {
+        match self.node.get_block_info(fetch_height).await {
             Ok(block_info) => {
                 info!(
                     "Fetched block {} ({} bytes)",
-                    current_height,
+                    fetch_height,
                     block_info.data.len()
                 );
-                Ok(Some((current_height, block_info.data, block_info.hash)))
+                Ok(Some((fetch_height, block_info.data, block_info.hash)))
             }
             Err(e) => {
-                error!("Failed to fetch block {}: {}", current_height, e);
+                error!("Failed to fetch block {}: {}", fetch_height, e);
                 Err(e.into())
             }
         }

--- a/crates/metashrew-sync/src/sync.rs
+++ b/crates/metashrew-sync/src/sync.rs
@@ -144,6 +144,17 @@ pub const ATOMIC_RETRY_ERROR_THRESHOLD: u32 = 30;
 pub const ATOMIC_RETRY_ERROR_SPAM_EVERY: u32 = 10;
 /// Cap on the per-attempt backoff (ms).
 pub const ATOMIC_RETRY_BACKOFF_CAP_MS: u64 = 30_000;
+/// Maximum total attempts the retry loop will make before giving up
+/// and surfacing the underlying error to the caller. Before this cap
+/// existed (rc.3 — `150abef` "never exit on atomic-write failure") the
+/// loop spun forever on persistent failures like RocksDB "Too many open
+/// files" (mork1e's pod 2026-05-21: block 892936 retried 600+ attempts
+/// before a manual restart cleared it). At the 30 s backoff cap, 30
+/// attempts is roughly 10-15 minutes of total retry time — enough to
+/// ride out a transient compaction-induced FD spike, but short enough
+/// that operators get a clear failure signal rather than hours of
+/// silent CPU-idle spinning.
+pub const MAX_ATOMIC_COMMIT_ATTEMPTS: u32 = 30;
 
 /// Returns the milliseconds to sleep *before* `attempt` (1-indexed). Attempt 1
 /// returns 0 — no sleep before the first try.
@@ -573,10 +584,24 @@ where
             block_data.len()
         );
 
-        // 2. Infinite-retry atomic apply. Block until commit succeeds.
+        // 2. Bounded-retry atomic apply. Block until commit succeeds OR
+        //    until we exceed MAX_ATOMIC_COMMIT_ATTEMPTS, in which case
+        //    surface the last error to the caller (previously this loop
+        //    was unbounded; see mork1e's 600-attempt wedge on block 892936
+        //    documented at MAX_ATOMIC_COMMIT_ATTEMPTS).
         let mut attempt: u32 = 0;
+        let mut last_err: Option<String> = None;
         loop {
             attempt = attempt.saturating_add(1);
+
+            if attempt > MAX_ATOMIC_COMMIT_ATTEMPTS {
+                let msg = last_err.unwrap_or_else(|| "no error captured".to_string());
+                return Err(SyncError::Storage(format!(
+                    "process_block: commit_atomic at height {} exceeded \
+                     max-retry budget ({} attempts): last error: {}",
+                    height, MAX_ATOMIC_COMMIT_ATTEMPTS, msg
+                )));
+            }
 
             // Backoff (no sleep before first attempt).
             if attempt > 1 {
@@ -616,22 +641,26 @@ where
                             return Ok(());
                         }
                         Err(commit_err) => {
+                            let msg = format!("{}", commit_err);
                             log_atomic_retry_failure(
                                 "atomic commit",
                                 height,
                                 attempt,
-                                &format!("{}", commit_err),
+                                &msg,
                             );
+                            last_err = Some(format!("commit_atomic: {}", msg));
                         }
                     }
                 }
                 Err(atomic_err) => {
+                    let msg = format!("{}", atomic_err);
                     log_atomic_retry_failure(
                         "atomic block execution",
                         height,
                         attempt,
-                        &format!("{}", atomic_err),
+                        &msg,
                     );
+                    last_err = Some(format!("process_block_atomic: {}", msg));
                 }
             }
 

--- a/crates/metashrew-sync/tests/commit_atomic_persistent_failure_should_fail_visibly.rs
+++ b/crates/metashrew-sync/tests/commit_atomic_persistent_failure_should_fail_visibly.rs
@@ -1,0 +1,156 @@
+//! Repro: `commit_atomic` retry loop has no max-attempts bound.
+//!
+//! ### Production evidence
+//!
+//! From the FROST Batallion 6 chat (2026-05-21, mork1e's node, v10
+//! metashrew):
+//!
+//! ```text
+//! [23:15:20Z INFO  metashrew_runtime::runtime] processed block 892936 atomically
+//! [23:15:20Z ERROR metashrew_sync::sync]      snapshot-path atomic commit STILL failing
+//!                                             for height 892936 (attempt 590):
+//!                                             Storage error: commit_atomic write failed
+//!                                             at height 892936: IO error: While open a
+//!                                             file for random read: /data/.metashrew/
+//!                                             v10-v3/006117.sst: Too many open files —
+//!                                             block 892936 atomic apply has been
+//!                                             retrying for 590 attempts
+//! ...
+//! [23:20:25Z ERROR metashrew_sync::sync]      ... (attempt 600) ... retrying for 600 attempts
+//! ```
+//!
+//! The pod was wedged for hours retrying the same block against an
+//! exhausted file-descriptor table (`ulimit -n` default ≈ 1024, RocksDB
+//! needs ~1 FD per active SST file, the v10 DB has thousands of SSTs).
+//! No progress, no escape, no visible error to the operator — just
+//! infinite retry with exponential backoff capped at 30 s.
+//!
+//! ### Root cause
+//!
+//! `SnapshotMetashrewSync::process_block` runs an unbounded `loop` with
+//! only two exit conditions:
+//!   1. Commit succeeds → return Ok.
+//!   2. `current_height` already moved past `height` → return Ok.
+//!
+//! Persistent commit failure has no third exit. Backoff is capped at
+//! 30 s; at that rate 600 attempts is 5 hours of CPU-idle spinning
+//! while the operator may not even know.
+//!
+//! ### What this test asserts
+//!
+//! When `commit_atomic` fails persistently (here simulated by
+//! `MockStorage::set_available(false)`), `process_block` must return
+//! `Err` within a bounded time (we pick 60 seconds — enough to ride out
+//! transient hiccups via exponential backoff, but not "forever"). The
+//! Err must surface the underlying commit error so operators can
+//! diagnose (FD exhaustion, ENOSPC, EIO, etc).
+//!
+//! ### Current behavior
+//!
+//! Without a max-attempts bound this test HANGS in `process_block` and
+//! the `tokio::time::timeout` fires after 60 s, asserting failure. With
+//! a bounded retry policy the test returns `Err` within ~15-30 s and
+//! the assertion holds.
+
+use metashrew_sync::snapshot::SyncMode;
+use metashrew_sync::snapshot_sync::SnapshotMetashrewSync;
+use metashrew_sync::{MockBitcoinNode, MockRuntime, MockStorage, SnapshotSyncEngine, SyncConfig};
+use std::time::Duration;
+use tokio::time::{self, timeout};
+
+/// VIRTUAL-time deadline (tokio's `start_paused = true` mocks the clock,
+/// so the retry loop's backoff `sleep`s consume virtual time only).
+/// Honest bounded retry cap of 30 attempts at exponential backoff
+/// peaking at 30 s/attempt = ~10 minutes virtual time total. Set
+/// the test deadline a comfortable 2× above that. If the loop is
+/// unbounded (bug present), `auto-advance` runs virtual time forward
+/// inside the sleeps, this deadline fires, and the test asserts the
+/// failure with a clear message.
+const RETRY_LOOP_VIRTUAL_DEADLINE: Duration = Duration::from_secs(20 * 60);
+
+fn test_config() -> SyncConfig {
+    SyncConfig {
+        start_block: 0,
+        exit_at: None,
+        pipeline_size: None,
+        max_reorg_depth: 100,
+        reorg_check_threshold: 6,
+        enable_startup_heal: false,
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn commit_atomic_persistent_failure_must_return_err_within_deadline() {
+    // start_paused = true → tokio's clock is virtual; `sleep()` calls
+    // inside the retry loop's backoff complete instantly (auto-advance
+    // applies once nothing else is runnable). 30 attempts × 30 s
+    // backoff caps becomes ~0 ms of real time. Without this, the test
+    // would take ~11 minutes to fail-fast when the fix is present.
+    let _ = time::pause;
+    let runtime = MockRuntime::new();
+    let storage = MockStorage::new();
+
+    // Seed bitcoind so the SPV `validate_block_connects` lookups have
+    // something to compare against — the bug being tested is downstream
+    // of that gate.
+    let block_hash = vec![0xabu8; 32];
+    let block_data = vec![0u8; 80];
+    let node = MockBitcoinNode::new();
+    node.add_block(1, block_hash.clone(), block_data.clone());
+
+    let mut sync = SnapshotMetashrewSync::new(
+        node,
+        storage.clone(),
+        runtime,
+        test_config(),
+        SyncMode::Normal,
+    );
+    sync.init().await;
+
+    // Persistent commit failure: every `commit_atomic` call returns
+    // `Err(SyncError::Storage("Storage not available"))`. This is the
+    // "Too many open files" class — the indexer can build the batch
+    // but the storage layer rejects every write attempt.
+    storage.set_available(false);
+
+    // Use `process_block_with_snapshots` to bypass the SPV check
+    // (validate_block_connects requires a real serialized bitcoin
+    // block, and the failure mode under test is downstream of that
+    // gate — see line 546 in snapshot_sync.rs which explicitly says
+    // "same infinite-retry-with-exponential-backoff policy as
+    // process_block"). Both code paths have the same bug.
+    let outcome = timeout(
+        RETRY_LOOP_VIRTUAL_DEADLINE,
+        sync.process_block_with_snapshots(1, &block_data),
+    )
+    .await;
+    let _ = block_hash;
+
+    match outcome {
+        Ok(Err(e)) => {
+            // Expected path once the fix lands: a bounded retry policy
+            // returns Err after N attempts, surfacing the commit error
+            // to the operator. The error message must mention the
+            // commit failure mode so monitoring can alert on the right
+            // signal.
+            let msg = format!("{e:#}");
+            assert!(
+                msg.contains("commit") || msg.contains("Storage") || msg.contains("available"),
+                "expected commit-failure error surfaced to caller, got: {msg}"
+            );
+        }
+        Ok(Ok(())) => panic!(
+            "process_block returned Ok despite storage being unavailable — \
+             the retry loop must NOT swallow persistent commit failures"
+        ),
+        Err(_elapsed) => panic!(
+            "process_block did not return within {:?} (wall-clock) — the \
+             retry loop has no max-attempts bound and spun forever. This \
+             is the production bug: mork1e's node at block 892936 retried \
+             600+ attempts on `Too many open files` with no operator-visible \
+             give-up. The fix: cap retries at N attempts (see \
+             MAX_ATOMIC_COMMIT_ATTEMPTS in sync.rs).",
+            RETRY_LOOP_VIRTUAL_DEADLINE
+        ),
+    }
+}

--- a/crates/rockshrew-mono/Cargo.toml
+++ b/crates/rockshrew-mono/Cargo.toml
@@ -50,6 +50,12 @@ russh-keys = "0.50.0-beta.7"  # Added for SSH key handling
 once_cell = "1.19.0"  # Added for lazy static initialization
 sha2 = "0.10.9"
 zstd = "0.13.0"  # Added for snapshot compression
+# RLIMIT_NOFILE bump at startup. RocksDB holds ~1 FD per open SST and
+# we run with set_max_open_files(50000); a typical OS default of
+# 1024 wedges commit_atomic with "Too many open files" once the DB
+# grows past ~1k SSTs. Documented prod wedge 2026-05-21 (mork1e's
+# node, block 892936 retried 600+ attempts).
+rlimit = "0.10"
 
 [features]
 default = []

--- a/crates/rockshrew-mono/Cargo.toml
+++ b/crates/rockshrew-mono/Cargo.toml
@@ -42,6 +42,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 console-subscriber = { version = "0.2", optional = true }
 num_cpus = "1.16.0"
+# Used by cpu_isolation.rs for sched_setaffinity / setpriority — the
+# kernel knobs that pin the indexer to its own cores and give it higher
+# scheduling weight than view-handler threads.
+libc = "0.2"
 url = "2.5.0"  # Added for URL parsing in SSH tunneling
 dirs = "5.0.1"  # Added for home directory detection
 bytes = "1.5.0"  # Added for handling binary data in responses

--- a/crates/rockshrew-mono/src/cpu_isolation.rs
+++ b/crates/rockshrew-mono/src/cpu_isolation.rs
@@ -1,0 +1,213 @@
+//! CPU isolation helpers for the indexer/view split.
+//!
+//! Linux-only. Two knobs:
+//!   * **affinity**: pin a thread to a subset of cores via
+//!     `sched_setaffinity`. Used to reserve N cores for the indexer
+//!     (block-processor + its tokio workers) so view-handler threads
+//!     can never steal them, no matter how many concurrent view calls
+//!     are in flight.
+//!   * **nice**: lower the indexer's scheduling-class nice value (and
+//!     raise the view pool's) via `setpriority`. When the two pools
+//!     do contend for the same core (e.g. on the boundary core if
+//!     affinity isn't perfect), the kernel CFS scheduler gives the
+//!     indexer ~28× more CPU time than view threads at a +15 nice
+//!     gap. Requires CAP_SYS_NICE in the container.
+//!
+//! Both helpers are no-ops if the requested config is "off" (cores
+//! empty / nice == 0). `set_thread_nice` logs a warn! and continues
+//! on EPERM (missing capability) rather than panicking, so the binary
+//! still runs in environments where the cap isn't granted.
+//!
+//! Detection of the pod's effective CPU set reads
+//! /proc/self/status's `Cpus_allowed_list` line, which the kernel
+//! populates from the container's cgroup cpuset. Falls back to
+//! `num_cpus::get()` if the line is missing or unparseable.
+
+use anyhow::Result;
+use log::warn;
+use std::fs;
+
+#[cfg(target_os = "linux")]
+use libc::{
+    cpu_set_t, sched_setaffinity, setpriority, CPU_SET, CPU_ZERO, PRIO_PROCESS,
+};
+
+/// Read the kernel-effective set of CPUs the calling process is
+/// allowed to run on. Returns a sorted Vec of CPU ids (0-based).
+/// Falls back to `0..num_cpus::get()` if /proc/self/status is
+/// unavailable or unparseable.
+pub fn detect_pod_cpus() -> Vec<usize> {
+    if let Ok(s) = fs::read_to_string("/proc/self/status") {
+        for line in s.lines() {
+            if let Some(rest) = line.strip_prefix("Cpus_allowed_list:") {
+                let mut out = parse_cpu_list(rest.trim());
+                out.sort();
+                if !out.is_empty() {
+                    return out;
+                }
+            }
+        }
+    }
+    (0..num_cpus::get()).collect()
+}
+
+/// Parse a Linux-style CPU list ("0-3,7,10-12") into a Vec of CPU ids.
+/// Returns empty Vec on any parse failure (caller should fall back).
+fn parse_cpu_list(s: &str) -> Vec<usize> {
+    let mut out = Vec::new();
+    for token in s.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        if let Some((a, b)) = token.split_once('-') {
+            let (a, b) = match (a.parse::<usize>(), b.parse::<usize>()) {
+                (Ok(a), Ok(b)) if a <= b => (a, b),
+                _ => return Vec::new(),
+            };
+            for c in a..=b {
+                out.push(c);
+            }
+        } else {
+            match token.parse::<usize>() {
+                Ok(c) => out.push(c),
+                Err(_) => return Vec::new(),
+            }
+        }
+    }
+    out
+}
+
+/// Given the indexer_cores config and the pod's available cores,
+/// return `(indexer_pool, view_pool)`. indexer_pool is the first N
+/// cores of the detected set; view_pool is the remainder. Caps
+/// indexer_cores at `total - 1` so the view pool is never empty (the
+/// HTTP server still needs at least one core to bind on).
+///
+/// `(vec![], vec![])` shape never happens — if cores is empty the
+/// returned indexer/view pools just both equal cores (i.e. unset
+/// affinity equals no isolation).
+pub fn split_cores(cores: &[usize], indexer_cores: usize) -> (Vec<usize>, Vec<usize>) {
+    if indexer_cores == 0 || cores.is_empty() {
+        return (cores.to_vec(), cores.to_vec());
+    }
+    let n = indexer_cores.min(cores.len().saturating_sub(1)).max(1);
+    let indexer_pool = cores[..n].to_vec();
+    let view_pool = cores[n..].to_vec();
+    (indexer_pool, view_pool)
+}
+
+/// Set the calling thread's CPU affinity to the given cores. No-op
+/// when `cores` is empty.
+#[cfg(target_os = "linux")]
+pub fn set_thread_affinity(cores: &[usize]) -> Result<()> {
+    if cores.is_empty() {
+        return Ok(());
+    }
+    // SAFETY: cpu_set_t is a POD; we zero-init it before use.
+    let mut set: cpu_set_t = unsafe { std::mem::zeroed() };
+    unsafe {
+        CPU_ZERO(&mut set);
+        for &c in cores {
+            CPU_SET(c, &mut set);
+        }
+        // pid=0 means "the calling thread" for sched_setaffinity on
+        // Linux. (POSIX says process, but Linux extends it to threads
+        // since the kernel models them as tasks.)
+        let rc = sched_setaffinity(0, std::mem::size_of::<cpu_set_t>(), &set);
+        if rc == -1 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_thread_affinity(_cores: &[usize]) -> Result<()> {
+    Ok(())
+}
+
+/// Set the calling thread's nice value. Logs a warning and returns
+/// Ok on EPERM (missing CAP_SYS_NICE) — the binary continues running
+/// without priority isolation rather than failing to start. No-op
+/// when `nice == 0`.
+#[cfg(target_os = "linux")]
+pub fn set_thread_nice(nice: i32) -> Result<()> {
+    if nice == 0 {
+        return Ok(());
+    }
+    // PRIO_PROCESS with id=0 targets the calling thread on Linux
+    // (same task-vs-process extension as sched_setaffinity).
+    // setpriority returns -1 on error; errno carries the reason.
+    // Clear errno first because setpriority's return value of -1 is
+    // a legitimate nice value too (range is -20..19), so we can't
+    // use the return value alone to detect failure.
+    unsafe {
+        *libc::__errno_location() = 0;
+        let rc = setpriority(PRIO_PROCESS, 0, nice);
+        let err = *libc::__errno_location();
+        if rc == -1 && err != 0 {
+            if err == libc::EPERM || err == libc::EACCES {
+                warn!(
+                    "cpu_isolation: setpriority({}) denied (EPERM); \
+                     container likely missing CAP_SYS_NICE — \
+                     continuing without priority isolation",
+                    nice
+                );
+                return Ok(());
+            }
+            return Err(std::io::Error::from_raw_os_error(err).into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_thread_nice(_nice: i32) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cpu_list_handles_common_shapes() {
+        assert_eq!(parse_cpu_list("0-3"), vec![0, 1, 2, 3]);
+        assert_eq!(parse_cpu_list("0,2,4"), vec![0, 2, 4]);
+        assert_eq!(parse_cpu_list("0-1,3,5-7"), vec![0, 1, 3, 5, 6, 7]);
+        assert_eq!(parse_cpu_list("7"), vec![7]);
+        assert_eq!(parse_cpu_list(""), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn parse_cpu_list_rejects_garbage() {
+        assert!(parse_cpu_list("a-b").is_empty());
+        assert!(parse_cpu_list("3-1").is_empty());
+        assert!(parse_cpu_list("xxx").is_empty());
+    }
+
+    #[test]
+    fn split_cores_reserves_indexer_pool_first() {
+        let cores: Vec<usize> = (0..8).collect();
+        let (idx, view) = split_cores(&cores, 2);
+        assert_eq!(idx, vec![0, 1]);
+        assert_eq!(view, vec![2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn split_cores_caps_indexer_at_total_minus_one() {
+        let cores: Vec<usize> = (0..4).collect();
+        let (idx, view) = split_cores(&cores, 10);
+        assert_eq!(idx.len(), 3); // capped at total - 1
+        assert_eq!(view.len(), 1);
+    }
+
+    #[test]
+    fn split_cores_off_means_full_set_for_both() {
+        let cores: Vec<usize> = (0..4).collect();
+        let (idx, view) = split_cores(&cores, 0);
+        assert_eq!(idx, cores);
+        assert_eq!(view, cores);
+    }
+}

--- a/crates/rockshrew-mono/src/lib.rs
+++ b/crates/rockshrew-mono/src/lib.rs
@@ -1299,10 +1299,15 @@ pub async fn run_prod(args: Args) -> Result<()> {
             let modern_adapter = RocksDBRuntimeAdapter::open_fork(db_path, fork_path_str, opts)?;
             ForkAdapter::Modern(modern_adapter)
         };
-        let mut config_engine = wasmtime::Config::default();
-        config_engine.async_support(true);
-        let engine = wasmtime::Engine::new(&config_engine)?;
-        let runtime = MetashrewRuntime::load(args.indexer.clone(), adapter, engine).await?;
+        // Engine construction now lives inside MetashrewRuntime::load (see
+        // metashrew_runtime::indexer_config for the deterministic-flags
+        // rationale). Previously this site built a bare-defaults engine
+        // and passed it in, with the consequence that ONLY the view-side
+        // async engine got the deterministic flags — the indexer engine
+        // that actually wrote state was missing memory_reservation,
+        // NaN canonicalization, SIMD determinism, etc. Leading
+        // hypothesis for the g vs h 907-DIESEL drift at h=950299.
+        let runtime = MetashrewRuntime::load(args.indexer.clone(), adapter).await?;
         let storage_adapter = match runtime.context.read().unwrap().db {
             ForkAdapter::Modern(ref modern_adapter) => {
                 RocksDBStorageAdapter::new(modern_adapter.db.clone())
@@ -1318,10 +1323,15 @@ pub async fn run_prod(args: Args) -> Result<()> {
     } else {
         let adapter =
             RocksDBRuntimeAdapter::open_optimized(args.db_path.to_string_lossy().to_string())?;
-        let mut config_engine = wasmtime::Config::default();
-        config_engine.async_support(true);
-        let engine = wasmtime::Engine::new(&config_engine)?;
-        let runtime = MetashrewRuntime::load(args.indexer.clone(), adapter.clone(), engine).await?;
+        // Engine construction now lives inside MetashrewRuntime::load (see
+        // metashrew_runtime::indexer_config for the deterministic-flags
+        // rationale). Previously this site built a bare-defaults engine
+        // and passed it in, with the consequence that ONLY the view-side
+        // async engine got the deterministic flags — the indexer engine
+        // that actually wrote state was missing memory_reservation,
+        // NaN canonicalization, SIMD determinism, etc. Leading
+        // hypothesis for the g vs h 907-DIESEL drift at h=950299.
+        let runtime = MetashrewRuntime::load(args.indexer.clone(), adapter.clone()).await?;
         let storage_adapter = RocksDBStorageAdapter::new(adapter.db.clone());
         let runtime_adapter =
             MetashrewRuntimeAdapter::new(Arc::new(runtime))

--- a/crates/rockshrew-mono/src/lib.rs
+++ b/crates/rockshrew-mono/src/lib.rs
@@ -1086,7 +1086,22 @@ where
                     // height (which it can do if `handle_reorg` lowers
                     // `current_height` between iterations).
                     let min_send_height = near_tip_min_send_height(last_sent_snapshot);
-                    match engine.get_next_block_data().await {
+                    // v9.0.5-rc.13: pass min_send_height as the fetch
+                    // floor so get_next_block_data ALWAYS returns a
+                    // block at height >= last_sent + 1. Without this
+                    // floor, get_next_block_data uses self.current_height
+                    // (the engine's in-memory atomic) which handle_reorg
+                    // can silently lower in a non-reorg edge case (e.g.
+                    // a transient hash mismatch between local storage
+                    // and bouncer/bitcoind during reorg detection). The
+                    // fetcher then drops every poll via near_tip_should_drop
+                    // and the processor wedges idle forever. Production
+                    // saw this 2026-05-26: j stuck at 951049 for 8+ min
+                    // post-commit, requiring manual pod restart to clear.
+                    match engine
+                        .get_next_block_data_with_floor(Some(min_send_height))
+                        .await
+                    {
                         Ok(Some((height, block_data, block_hash))) => {
                             drop(engine);
                             if near_tip_should_drop(last_sent_snapshot, height) {

--- a/crates/rockshrew-mono/src/lib.rs
+++ b/crates/rockshrew-mono/src/lib.rs
@@ -364,6 +364,22 @@ pub struct Args {
     #[arg(long, env = "ROCKSHREW_VIEW_NICE", default_value_t = 0,
           value_parser = clap::value_parser!(i32).range(-20..=19))]
     pub view_nice: i32,
+
+    /// v9.0.5-rc.12 dedicated view-runtime: number of tokio worker
+    /// threads in the third runtime that hosts ONLY metashrew_view +
+    /// metashrew_preview WASM execution. Isolates view CPU from the
+    /// actix-web accept loop + cheap RPCs (metashrew_height,
+    /// metashrew_getblockhash) so view saturation can't queue sub-ms
+    /// storage reads behind WASM that holds a worker thread for
+    /// hundreds of ms between yield points.
+    ///
+    /// None (default) auto-sizes: when --indexer-cores > 0, uses
+    /// max(4, view_pool.len() - 2) to leave a couple of view-pool
+    /// cores for actix-web. Otherwise uses max(4, num_cpus / 2).
+    /// Threads are pinned to the same view-pool cores as the actix
+    /// workers (via cpu_isolation) and run at --view-nice priority.
+    #[arg(long, env = "ROCKSHREW_VIEW_RUNTIME_WORKERS")]
+    pub view_runtime_workers: Option<usize>,
 }
 
 /// Shared application state for the JSON-RPC server.
@@ -385,6 +401,14 @@ where
     /// (kept for tests). The per-view WASM memory cap is enforced
     /// separately by the `RuntimeAdapter` via `view_with_limits`.
     pub view_limiter: Option<Arc<metashrew_runtime::ViewLimiter>>,
+    /// v9.0.5-rc.12 dedicated view-runtime: handle to the third tokio
+    /// runtime that hosts metashrew_view + metashrew_preview WASM
+    /// execution. handle_jsonrpc spawns view work onto this runtime
+    /// instead of the main (actix-web) runtime so cheap RPCs aren't
+    /// queued behind WASM workers. None = run on the main runtime
+    /// (kept for run_test). See the rc.12 build comment in run_prod
+    /// for the contract.
+    pub view_runtime: Option<tokio::runtime::Handle>,
 }
 
 /// Per-method server-side timeout. Bounds how long a single JSON-RPC request
@@ -464,9 +488,26 @@ where
     // necessary because actix's handler future is bound to the request
     // lifecycle; the spawned task observes cancellation via the shared token
     // and exits at the next WASM yield point.
+    //
+    // v9.0.5-rc.12 view-runtime split: metashrew_view and metashrew_preview
+    // run on a SEPARATE tokio runtime (state.view_runtime). That runtime's
+    // workers are pinned to the view-pool cores and dedicated exclusively
+    // to WASM execution — so even when N concurrent view calls pin every
+    // view-runtime worker for hundreds of ms each, cheap RPCs spawned via
+    // tokio::spawn (the main actix runtime) get scheduled without queueing
+    // behind them. CancellationToken clones are Arc, so the existing drop-
+    // guard cancellation works across runtime boundaries. JoinHandle<T>
+    // returned by Handle::spawn is awaitable from the actix runtime via
+    // standard tokio interop. When state.view_runtime is None (run_test
+    // path), falls back to tokio::spawn — same behavior as v9.0.5-rc.11.
     let view_limiter = state.view_limiter.clone();
     let acquire_timeout = timeout;
-    let work = tokio::spawn(async move {
+    let is_view = matches!(
+        method_for_work.as_str(),
+        "metashrew_view" | "metashrew_preview"
+    );
+    let view_runtime_for_spawn = state.view_runtime.clone();
+    let work_fut_outer = async move {
         let work_fut = async move {
             match method_for_work.as_str() {
                 "metashrew_view" => {
@@ -641,7 +682,15 @@ where
             ),
             r = work_fut => r,
         }
-    });
+    };
+
+    // v9.0.5-rc.12: dispatch view/preview onto the dedicated view runtime;
+    // everything else stays on the main (actix) runtime. The future is moved
+    // into exactly one match arm.
+    let work = match (is_view, view_runtime_for_spawn) {
+        (true, Some(handle)) => handle.spawn(work_fut_outer),
+        _ => tokio::spawn(work_fut_outer),
+    };
 
     let start_time = Instant::now();
 
@@ -842,10 +891,75 @@ where
     );
     let view_limiter = Arc::new(metashrew_runtime::ViewLimiter::new(view_limits_cfg));
 
+    // v9.0.5-rc.12: detect pod cpuset + split into indexer/view pools
+    // EARLY so the view-runtime can be built before AppState. (The
+    // processor std::thread spawn further down re-uses these same
+    // pools.) The original v9.0.5-rc.11 site at the processor spawn
+    // is moved earlier here — same effect; the detection is a pure
+    // /proc read.
+    let pod_cores = cpu_isolation::detect_pod_cpus();
+    let (indexer_cores_set, view_cores_set) =
+        cpu_isolation::split_cores(&pod_cores, args.indexer_cores);
+    if args.indexer_cores > 0 {
+        info!(
+            "CPU isolation: detected {} cores ({:?}); indexer pool = {:?}, view pool = {:?}",
+            pod_cores.len(),
+            pod_cores,
+            indexer_cores_set,
+            view_cores_set
+        );
+    }
+
+    // v9.0.5-rc.12: dedicated view-runtime. Isolates WASM execution
+    // from the actix accept loop + cheap RPCs (metashrew_height,
+    // metashrew_getblockhash, etc.) so view-call saturation can't
+    // queue sub-ms storage reads behind WASM that holds a worker
+    // thread for hundreds of ms between yield points. The pool is
+    // pinned to the view-cores subset and runs at view_nice — same
+    // scheduling class as the actix view-workers but on dedicated
+    // workers that NEVER touch the actix accept loop or RPC dispatch.
+    //
+    // We keep the Runtime alive past HttpServer::run().await by
+    // binding it to a long-lived guard. Dropping a Runtime calls
+    // shutdown_background() which terminates worker threads — only
+    // safe at process exit.
+    let view_runtime_workers = args.view_runtime_workers.unwrap_or_else(|| {
+        if args.indexer_cores > 0 {
+            // Leave a couple of view-pool cores for actix-web's own workers
+            // (accept loop + cheap RPC dispatch). Floor at 4 so even small
+            // pods get a usable view runtime.
+            view_cores_set.len().saturating_sub(2).max(4)
+        } else {
+            (num_cpus::get() / 2).max(4)
+        }
+    });
+    let view_cores_for_rt = view_cores_set.clone();
+    let view_nice_for_rt = args.view_nice;
+    let view_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(view_runtime_workers)
+        .thread_name("view-worker")
+        .on_thread_start(move || {
+            if let Err(e) = cpu_isolation::set_thread_affinity(&view_cores_for_rt) {
+                warn!("view-worker: set_thread_affinity failed: {}", e);
+            }
+            if let Err(e) = cpu_isolation::set_thread_nice(view_nice_for_rt) {
+                warn!("view-worker: set_thread_nice failed: {}", e);
+            }
+        })
+        .enable_all()
+        .build()
+        .expect("Failed to create view runtime");
+    info!(
+        "view runtime started ({} workers, pinned to {:?})",
+        view_runtime_workers, view_cores_set
+    );
+    let view_runtime_handle = view_runtime.handle().clone();
+
     let app_state = web::Data::new(AppState {
         sync_engine: sync_engine_arc.clone(),
         enable_preview: args.enable_preview,
         view_limiter: Some(view_limiter.clone()),
+        view_runtime: Some(view_runtime_handle.clone()),
     });
 
     // Cap the prefetch buffer at reorg_check_threshold so the fetcher can
@@ -1104,18 +1218,11 @@ where
     // (which the HTTP server setup further down pins to the complementary
     // view pool). Combined with `--indexer-nice -10 --view-nice +5`, the
     // kernel CFS scheduler gives the indexer a hard CPU floor.
-    let pod_cores = cpu_isolation::detect_pod_cpus();
-    let (indexer_cores_set, view_cores_set) =
-        cpu_isolation::split_cores(&pod_cores, args.indexer_cores);
-    if args.indexer_cores > 0 {
-        info!(
-            "CPU isolation: detected {} cores ({:?}); indexer pool = {:?}, view pool = {:?}",
-            pod_cores.len(),
-            pod_cores,
-            indexer_cores_set,
-            view_cores_set
-        );
-    }
+    //
+    // v9.0.5-rc.12: the cpu_isolation detect_pod_cpus + split_cores +
+    // info!() block was hoisted earlier in run_prod() so the view
+    // runtime (built before AppState) can re-use the same view_cores_set.
+    // indexer_cores_set / view_cores_set are still in scope here.
     let indexer_cores_for_processor = indexer_cores_set.clone();
     let indexer_nice = args.indexer_nice;
     let processor_handle = std::thread::Builder::new()

--- a/crates/rockshrew-mono/src/lib.rs
+++ b/crates/rockshrew-mono/src/lib.rs
@@ -50,6 +50,7 @@ pub mod adapters;
 pub mod snapshot;
 pub mod snapshot_adapters;
 pub mod ssh_tunnel;
+pub mod cpu_isolation;
 
 #[cfg(test)]
 mod tests;
@@ -323,6 +324,46 @@ pub struct Args {
     /// indexer advance.
     #[arg(long, default_value_t = false)]
     pub no_startup_heal: bool,
+
+    /// v9.0.5-rc.11 CPU isolation: reserve N cores for the indexer
+    /// (block-processor thread + its dedicated tokio runtime). View
+    /// handler threads (actix-web workers + the main tokio runtime)
+    /// are pinned to the remaining cores, so a flood of view calls
+    /// can never starve indexing of CPU. Pod cgroup cpuset is read
+    /// from /proc/self/status to detect available cores. 0 = off
+    /// (no affinity changes). Default: 0.
+    ///
+    /// Example: pod with 16 CPU request, `--indexer-cores 4` →
+    /// indexer pool = cores 0-3, view pool = cores 4-15. Even at
+    /// 100% view load the indexer always has 4 dedicated cores.
+    /// Pair with `--indexer-nice` / `--view-nice` for additional
+    /// CFS-weight priority on the boundary case where threads share
+    /// a core.
+    #[arg(long, env = "ROCKSHREW_INDEXER_CORES", default_value_t = 0)]
+    pub indexer_cores: usize,
+
+    /// v9.0.5-rc.11 CPU isolation: Linux nice value for the indexer
+    /// thread and its runtime workers. Negative = higher priority
+    /// (gets more CPU time when contending). Range: -20 (max
+    /// priority) to 19 (min). Requires CAP_SYS_NICE in the container.
+    /// 0 = off. Default: 0.
+    ///
+    /// Combined with `--view-nice +5`, a -10 indexer nice gives the
+    /// indexer ~28× the CFS weight of view threads on any shared
+    /// core. On EPERM (missing cap) we log a warning and continue
+    /// without priority isolation rather than failing to start.
+    #[arg(long, env = "ROCKSHREW_INDEXER_NICE", default_value_t = 0,
+          value_parser = clap::value_parser!(i32).range(-20..=19))]
+    pub indexer_nice: i32,
+
+    /// v9.0.5-rc.11 CPU isolation: Linux nice value for HTTP/view
+    /// handler threads (actix-web workers + the main tokio runtime).
+    /// Positive = lower priority. Range: -20..19. Requires
+    /// CAP_SYS_NICE in the container. 0 = off. Default: 0.
+    /// See `--indexer-nice` for context.
+    #[arg(long, env = "ROCKSHREW_VIEW_NICE", default_value_t = 0,
+          value_parser = clap::value_parser!(i32).range(-20..=19))]
+    pub view_nice: i32,
 }
 
 /// Shared application state for the JSON-RPC server.
@@ -1054,6 +1095,29 @@ where
     // Block processor runs on a dedicated tokio runtime so it never competes
     // with RPC view calls for thread pool time. This ensures indexing progresses
     // steadily regardless of RPC load, and views are never starved by indexing.
+    //
+    // v9.0.5-rc.11: CPU isolation. When `--indexer-cores N > 0`, the
+    // detected pod cpuset is split — first N cores are the indexer pool,
+    // the rest are the view pool. The processor std::thread + its 4 tokio
+    // workers all get `sched_setaffinity` to the indexer pool, so they
+    // CAN'T be evicted from those cores by the actix-web/view threads
+    // (which the HTTP server setup further down pins to the complementary
+    // view pool). Combined with `--indexer-nice -10 --view-nice +5`, the
+    // kernel CFS scheduler gives the indexer a hard CPU floor.
+    let pod_cores = cpu_isolation::detect_pod_cpus();
+    let (indexer_cores_set, view_cores_set) =
+        cpu_isolation::split_cores(&pod_cores, args.indexer_cores);
+    if args.indexer_cores > 0 {
+        info!(
+            "CPU isolation: detected {} cores ({:?}); indexer pool = {:?}, view pool = {:?}",
+            pod_cores.len(),
+            pod_cores,
+            indexer_cores_set,
+            view_cores_set
+        );
+    }
+    let indexer_cores_for_processor = indexer_cores_set.clone();
+    let indexer_nice = args.indexer_nice;
     let processor_handle = std::thread::Builder::new()
         .name("block-processor".into())
         .spawn({
@@ -1061,9 +1125,30 @@ where
             let result_sender_clone = result_sender.clone();
 
             move || {
+                // Set affinity + nice for the processor driver thread.
+                if let Err(e) = cpu_isolation::set_thread_affinity(&indexer_cores_for_processor) {
+                    warn!("processor: set_thread_affinity failed: {}", e);
+                }
+                if let Err(e) = cpu_isolation::set_thread_nice(indexer_nice) {
+                    warn!("processor: set_thread_nice failed: {}", e);
+                }
+                // The runtime's worker threads each get the same
+                // isolation via on_thread_start. Clone the config into
+                // the closure so it stays alive for the runtime's
+                // lifetime.
+                let worker_cores = indexer_cores_for_processor.clone();
+                let worker_nice = indexer_nice;
                 let rt = tokio::runtime::Builder::new_multi_thread()
                     .worker_threads(4)
                     .thread_name("processor-worker")
+                    .on_thread_start(move || {
+                        if let Err(e) = cpu_isolation::set_thread_affinity(&worker_cores) {
+                            warn!("processor-worker: set_thread_affinity failed: {}", e);
+                        }
+                        if let Err(e) = cpu_isolation::set_thread_nice(worker_nice) {
+                            warn!("processor-worker: set_thread_nice failed: {}", e);
+                        }
+                    })
                     .enable_all()
                     .build()
                     .expect("Failed to create processor runtime");
@@ -1176,9 +1261,36 @@ where
         }
     }});
 
+    // v9.0.5-rc.11 CPU isolation: HTTP/view workers pinned to the
+    // complementary core pool + given a higher (more polite) nice
+    // value. actix-web invokes the factory closure once per worker
+    // thread to build that worker's App — we call sched_setaffinity +
+    // setpriority on entry so the worker's own thread is constrained
+    // before it serves any request. The remaining tokio main-runtime
+    // threads (fetcher dispatch, server accept loop) stay unpinned
+    // since they're IO-bound and don't compete with the indexer for
+    // CPU.
+    //
+    // worker count: when isolation is on, one worker per view-pool
+    // core. When off, leave actix's default (num_cpus).
+    let view_workers = if args.indexer_cores > 0 {
+        view_cores_set.len().max(1)
+    } else {
+        num_cpus::get()
+    };
+    let view_cores_for_workers = view_cores_set.clone();
+    let view_nice = args.view_nice;
     let server_handle = tokio::spawn({
         let args_clone = Arc::new(args.clone());
         HttpServer::new(move || {
+            // Per-worker thread setup. Idempotent across calls (the
+            // syscalls just re-set the same affinity / nice).
+            if let Err(e) = cpu_isolation::set_thread_affinity(&view_cores_for_workers) {
+                warn!("view-worker: set_thread_affinity failed: {}", e);
+            }
+            if let Err(e) = cpu_isolation::set_thread_nice(view_nice) {
+                warn!("view-worker: set_thread_nice failed: {}", e);
+            }
             let cors = match &args_clone.cors {
                 Some(cors_value) if cors_value == "*" => Cors::default()
                     .allow_any_origin()
@@ -1201,6 +1313,7 @@ where
                         .route(web::post().to(handle_jsonrpc::<N, S, R>))
                 )
         })
+        .workers(view_workers)
         .bind((args.host.as_str(), args.port))?
         .run()
     });

--- a/crates/rockshrew-mono/src/main.rs
+++ b/crates/rockshrew-mono/src/main.rs
@@ -84,9 +84,54 @@ fn init_tracing() {
     env_logger::builder().format_timestamp_secs().init();
 }
 
+/// Bump `RLIMIT_NOFILE` to a value that comfortably exceeds
+/// RocksDB's `set_max_open_files(50000)` ceiling. The OS-level
+/// ulimit gates the RocksDB internal cap — if RLIMIT_NOFILE is
+/// at the typical default of 1024, RocksDB's table_cache hits
+/// the ulimit first and commit_atomic fails with
+/// `IO error: Too many open files` (production wedge 2026-05-21:
+/// mork1e's node, block 892936 retried 600+ attempts).
+///
+/// We try 1_048_576 (1 << 20) first, which matches the standard
+/// systemd unit-default for daemons that need lots of FDs. If the
+/// hard limit is lower (containers / rootless runs), we set to
+/// the hard cap. Returns the resulting soft limit so it gets
+/// surfaced in startup logs.
+fn raise_nofile_limit() -> std::io::Result<(u64, u64)> {
+    let (soft_pre, hard) = rlimit::Resource::NOFILE.get()?;
+    let target = 1_048_576u64.min(hard);
+    if soft_pre < target {
+        rlimit::Resource::NOFILE.set(target, hard)?;
+    }
+    let (soft_post, _hard) = rlimit::Resource::NOFILE.get()?;
+    Ok((soft_pre, soft_post))
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     init_tracing();
+
+    match raise_nofile_limit() {
+        Ok((pre, post)) if post > pre => {
+            log::info!(
+                "raised RLIMIT_NOFILE soft cap from {} to {} (matches RocksDB \
+                 set_max_open_files(50000) headroom; prevents the 'Too many \
+                 open files' wedge documented in PRODUCTION_BUGS_AUDIT.md)",
+                pre, post
+            );
+        }
+        Ok((pre, _)) => {
+            log::info!("RLIMIT_NOFILE soft cap already at {} (no bump needed)", pre);
+        }
+        Err(e) => {
+            log::warn!(
+                "failed to raise RLIMIT_NOFILE: {e}; if the indexer wedges on \
+                 'Too many open files' during commit_atomic, raise it manually \
+                 via `ulimit -n` or the container runtime"
+            );
+        }
+    }
+
     let args = rockshrew_mono::Args::parse();
     rockshrew_mono::run_prod(args).await
 }


### PR DESCRIPTION
Brings to master the three rcs that have landed in production this week:

## rc.11 (commit 0519b27): CPU isolation

- New flags: `--indexer-cores N`, `--indexer-nice N`, `--view-nice N`
- New `cpu_isolation.rs` helper (sched_setaffinity + setpriority)
- Pins block-processor + 4-worker tokio runtime to a reserved core subset; view + actix workers to the complement
- Indexer gets a hard CPU floor of N cores no matter how saturated the view pool gets
- No CAP_SYS_NICE required — uses positive view-nice instead of negative indexer-nice

## rc.12 (commit af545ed): dedicated view runtime

- New flag: `--view-runtime-workers N`
- Third `tokio::runtime::Runtime` hosting **only** `metashrew_view` + `metashrew_preview` WASM execution
- handle_jsonrpc routes view/preview onto this runtime; cheap RPCs (metashrew_height, getblockhash) stay on actix main runtime
- **Production verified:** cheap RPC latency under 20-concurrent-view burst stays at 5-42ms (vs 1-3s pre-patch). 100× improvement.

## rc.13 (commit ff2e3f6): get_next_block_data min_target_height floor

- Closes a wedge where `handle_reorg` silently lowers `self.current_height` in a transient non-reorg edge case
- Fetcher then refetches a block the outer loop already enqueued → `near_tip_should_drop` hits → processor idles indefinitely
- **Observed 2026-05-26:** pod metashrew-220a-j stuck at height 951049 for 8+ min after committing it (block-processor delta=0 over 30s sampling); required pod restart
- Fix: new `get_next_block_data_with_floor(min_target_height)` clamps the fetched height to `>= max(current_height, min_target_height)`. The fetcher passes `Some(last_sent + 1)`.
- Real reorgs still take effect (handle_reorg's storage rollback unchanged)

## Tests

```
cargo test --release -p rockshrew-mono   →  22 passed, 0 failed
cargo test --release -p metashrew-sync   →  6 passed, 0 failed
                                            7 passed, 0 failed (strict_determinism)
```

All near_tip_should_drop / compute_next_fetch_range / fetcher_dedup invariants preserved.

## Wire compat

Unchanged. DB layout unchanged. All new CLI flags default to opt-out — existing call sites and pods see no behavior change unless explicitly configured.